### PR TITLE
Add JSON return functionality for search database endpoints

### DIFF
--- a/Database/src/views.py
+++ b/Database/src/views.py
@@ -47,8 +47,8 @@ def get_track(id):
 
     Returns
     -------
-    str 
-        an HTML display text.
+    JSON or HTML 
+        JSON response if requested, otherwise renders an HTML template.
     """
 
     try:    


### PR DESCRIPTION
Adds functionality so that a JSON format of a list of all tracks or an individual track can be retreived from existing endpoints in the database if the the request header contains `application/json`.

This is needed so other microservices can query the database to retrieve information about tracks.